### PR TITLE
Add image_create_multiple

### DIFF
--- a/VTFLib.py
+++ b/VTFLib.py
@@ -188,7 +188,17 @@ class VTFLib:
     def image_create_single(self, width, height, image_data, options):
         image_data = cast(image_data, POINTER(c_byte))
         return self.ImageCreateSingle(width, height, image_data, options)
-
+    
+    ImageCreateMultiple = vtflib_cdll.vlImageCreateMultiple
+    ImageCreateMultiple.argtypes = [
+        c_int32, c_int32, c_int32, c_int32, c_int32, POINTER(c_byte), POINTER(
+            VTFLibStructures.CreateOptions)]
+    ImageCreateMultiple.restype = c_bool
+        
+    def image_create_multiple(self, width, height, frames, faces, slices, image_data, options):
+        image_data = cast(image_data, POINTER(c_byte))
+        return self.ImageCreateMultiple(width, height, frames, faces, slices, image_data, options)
+    
     ImageDestroy = vtflib_cdll.vlImageDestroy
     ImageDestroy.argtypes = []
     ImageDestroy.restype = None


### PR DESCRIPTION
When trying to create animated .vtf's, had to figure out how to create one that had specific options set to reduce file size. vlImageCreateMultiple was the only one that actually listened to the image format.

https://pastebin.com/ETZk9b56 for a sample that uses it to automatically generate animated .vtf's via a quick tuxie.py --input=folder/*.png --output=output.vtf :)